### PR TITLE
Update metalsmith dependency to ^1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "metalsmith": "^0.11.0"
+    "metalsmith": "^1.0.0"
   }
 }


### PR DESCRIPTION
I have a few metalsmith dependencies that require a `1.x.x` release of metalsmith, so I'd appreciate having the metalsmith dependency bumped!

I've chosen the caret range selector to match the consistency of the other npm dependencies.

Cheers,
Michael
