### PR TITLE
added option empty object fallbacks incase not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "metalsmith": "^0.11.0"
+    "metalsmith": "^1.0.1"
   }
 }

--- a/tasks/metalsmith.js
+++ b/tasks/metalsmith.js
@@ -16,7 +16,9 @@ module.exports = function(grunt) {
     var done = this.async();
 
     var options = this.options({
-      clean: true
+      clean: true,
+      metadata : {},
+      plugins : {}
     });
 
     this.files.forEach(function(f) {


### PR DESCRIPTION
When you don't define a metadata block in your config you get a fatal error. Added a safeguard for metadata and plugins object literals
